### PR TITLE
Memory leaks fix and native/jni optimizations

### DIFF
--- a/serial4j-native/CMakeLists.txt
+++ b/serial4j-native/CMakeLists.txt
@@ -28,7 +28,8 @@ set(headers "${CMAKE_CURRENT_SOURCE_DIR}/src/include/"
 
 set(sources "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/jni/com_serial4j_core_serial_NativeTerminalDevice.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/jni/com_serial4j_core_errno_NativeErrno.cpp"
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/linux/TerminalDevice.cpp")
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/linux/TerminalDevice.cpp"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/DynamicBuffer.cpp")
 
 # add a library target
 add_library(${library} SHARED ${sources})

--- a/serial4j-native/src/include/BufferUtils.h
+++ b/serial4j-native/src/include/BufferUtils.h
@@ -60,10 +60,10 @@ namespace BufferUtils {
      * @param buffer the buffer to free its cells.
      * @param count the number of cells to free, starting from index zero.
      */
-    static inline void freeBufferCells(void** buffer, int* count) {
-        for (int i = 0; i < *count; i++) {
-            BufferUtils::nullifyBuffer(buffer, i);
+    static inline void freeBufferCells(void** buffer, int count) {
+        for (int i = 0; i < count; i++) {
             free(buffer[i]);
+            BufferUtils::nullifyBuffer(buffer, i);
         }
     }
     
@@ -85,9 +85,9 @@ namespace BufferUtils {
      * @param count the count length of the buffer.
      * @return void** a new buffer with the same data as the source.
      */
-    static inline void** copy(void** src, int* count) {
+    static inline void** copy(void** src, int count) {
         void** copy = (void**) calloc(1, sizeof(void**));
-        for (int i = 0; i < *count; i++) {
+        for (int i = 0; i < count; i++) {
             /* add new memory on the next array block */
             copy[i] = (void*) calloc(1, sizeof(void*));
             copy[i] = src[i];
@@ -101,22 +101,21 @@ namespace BufferUtils {
      * @param buffer the buffer to re-validate.
      * @param count the pointers count.
      */
-    static inline void reValidateBuffer(void** buffer, int* count, int* isProcessed) {
+    static inline void reValidateBuffer(void** buffer, int count) {
         /* get a temp copy from flagged buffer */
         void** temp = BufferUtils::copy(buffer, count);
         /* free the buffer cells to prepare the buffer to be reinitialized */
         BufferUtils::freeBufferCells(buffer, count);
         /* re-init the buffer, removing the null pointers */
-        for (int i = 0, j = 0; i < *count; i++) {
+        for (int i = 0, j = 0; i < count; i++) {
             if (temp[i] == NULL) {
-                printf("%s\n", "zero");
+                 printf("%s\n", "zero");
                 continue;
             }
             buffer[j] = (void*) calloc(1, sizeof(void*));
             buffer[j] = temp[i];
             j++;
         }
-        *isProcessed = 1;
         /* free the temp buffer */
         BufferUtils::freeBufferCells(temp, count);
     }

--- a/serial4j-native/src/include/BufferUtils.h
+++ b/serial4j-native/src/include/BufferUtils.h
@@ -109,7 +109,6 @@ namespace BufferUtils {
         /* re-init the buffer, removing the null pointers */
         for (int i = 0, j = 0; i < count; i++) {
             if (temp[i] == NULL) {
-                 printf("%s\n", "zero");
                 continue;
             }
             buffer[j] = (void*) calloc(1, sizeof(void*));

--- a/serial4j-native/src/include/DynamicBuffer.h
+++ b/serial4j-native/src/include/DynamicBuffer.h
@@ -43,114 +43,122 @@
 #include<ErrnoUtils.h>
 #include<BufferUtils.h>
 
-struct DynamicBuffer {
+class DynamicBuffer {
+    public:
+            /**
+             * @brief Initializes a buffer of pointers.
+             */
+            DynamicBuffer() {
+                 buffer = (void**) calloc(1, sizeof(void**));
+            }
 
-    int count = 0;
-    int isProcessed = 0;
+            ~DynamicBuffer() {
+                BufferUtils::freeBufferCells(buffer, count);
+            }
 
-    /**
-     * Declares and initializes a pointer that points to 
-     * other void* buffers starting from index zero. 
-     * 
-     * @note The pointer is of single size of a type.
-     * @note The pointer points to only and only one buffer at a time.
-     * @note New buffers can be added to this pointer by dereferencing it and adding one to the memory address to move 
-     * it to a new cell block.
-     * e.g: 
-     * 1) First way of adding a new buffer to this pointer using the deep copy:
-     *     buffer[index] = (void*) calloc(1, sizeof(void*));
-     *     buffer[index] = item;
-     * 
-     * 2) Second way of adding a new buffer to this pointer (the one used here):
-     *     *(buffer += count) = (void*) calloc(1, sizeof(void*));
-     *     *buffer = item;
-     *     buffer -= count;
-     * 
-     * 3) The superficial copy example:
-     *     buffer[index] = item;
-     */
-    void** buffer = (void**) calloc(1, sizeof(void**));;
+            /**
+             * Declares and initializes a pointer that points to
+             * other void* buffers starting from index zero.
+             *
+             * @note The pointer is of single size of a type.
+             * @note The pointer points to only and only one buffer at a time.
+             * @note New buffers can be added to this pointer by dereferencing it and adding one to the memory address to move
+             * it to a new cell block.
+             * e.g:
+             * 1) First way of adding a new buffer to this pointer using the deep copy:
+             *     buffer[index] = (void*) calloc(1, sizeof(void*));
+             *     buffer[index] = item;
+             *
+             * 2) Second way of adding a new buffer to this pointer (the one used here):
+             *     *(buffer += count) = (void*) calloc(1, sizeof(void*));
+             *     *buffer = item;
+             *     buffer -= count;
+             *
+             * 3) The superficial copy example:
+             *     buffer[index] = item;
+             */
+            void** buffer;
 
-    static inline struct DynamicBuffer* createNewInstance() {
-        return (struct DynamicBuffer*) calloc(1, sizeof(struct DynamicBuffer));
-    }
+            /**
+             * Retrieves the pointer to this dynamic buffer.
+             *
+             * @return a pointer to this array of buffers.
+             */
+            virtual void** getBuffer() {
+                return buffer;
+            }
 
-    /**
-     * Retrieves the pointer to this dynamic buffer.
-     * 
-     * @return a pointer to this array of buffers.
-     */
-    void** getBuffer() {
-        return buffer;
-    }
+            /**
+             * Retrieves this structure size.
+             *
+             * @return an integer representing this struct in bytes.
+             */
+            virtual size_t getBufferSize() {
+                return sizeof(struct DynamicBuffer);
+            }
 
-    /**
-     * Retrieves this structure size.
-     * 
-     * @return an integer representing this struct in bytes.
-     */
-    size_t getBufferSize() {
-        return sizeof(struct DynamicBuffer);
-    }
+            /**
+             * Resets the pointer value back to zero.
+             */
+            virtual void resetDataPointer() {
+                this->count = 0;
+            }
 
-    /**
-     * Resets the pointer value back to zero.
-     */
-    void resetDataPointer() {
-        this->count = 0;
-    }
+            /**
+             * Gets the memory address to the integer of the items count.
+             *
+             * @return a pointer referring to the memory address of the integer that represents the item counts.
+             */
+            virtual int* getItemsCount();
 
-    /**
-     * Gets the memory address to the integer of the items count.
-     * 
-     * @return a pointer referring to the memory address of the integer that represents the item counts.
-     */
-    int* getItemsCount();
+            /**
+             * Adds a new buffer to this pointer in a new index.
+             *
+             * @param item a void* buffer to add.
+             */
+            virtual void add(void* item);
 
-    /**
-     * Adds a new buffer to this pointer in a new index.
-     * 
-     * @param item a void* buffer to add.
-     */
-    void add(void* item);
+            /**
+             * Adds a new buffer on a particular location in this pointer replacing an old one if exists.
+             *
+             * @param index the index where the new buffer will be located in this pointer.
+             * @param item the buffer to add.
+             */
+            virtual void add(int index, void* item);
 
-    /**
-     * Adds a new buffer on a particular location in this pointer replacing an old one if exists.
-     * 
-     * @param index the index where the new buffer will be located in this pointer.
-     * @param item the buffer to add.
-     */
-    void add(int index, void* item);
+            /**
+             * Frees a buffer from the memory at a particular index.
+             * @warning this method call is expensive as it removes and revalidates the whole buffer from NULL pointers.
+             *
+             * @param index the index of the buffer to remove.
+             */
+            virtual void removeAt(int index);
 
-    /**
-     * Frees a buffer from the memory at a particular index.
-     * @warning this method call is expensive as it removes and revalidates the whole buffer from NULL pointers.
-     * 
-     * @param index the index of the buffer to remove.
-     */
-    void removeAt(int index);
+            /**
+             * Frees all the buffers of this pointer from the memory.
+             */
+            virtual void removeAll();
 
-    /**
-     * Frees all the buffers of this pointer from the memory.
-     */
-    void removeAll();
+            /**
+             * Retrieves a buffer index.
+             *
+             * @param item the buffer to get its index.
+             * @return the buffer index in an integer format.
+             */
+            virtual int getItemIndex(void* item);
 
-    /**
-     * Retrieves a buffer index.
-     * 
-     * @param item the buffer to get its index.
-     * @return the buffer index in an integer format.
-     */
-    int getItemIndex(void* item);
+            /**
+             * Retrieves a buffer from this pointer using its index.
+             *
+             * @param index the index where the buffer is located in this pointer.
+             * @return the buffer corresponding to this index.
+             */
+            virtual void* getItem(int index);
 
-    /**
-     * Retrieves a buffer from this pointer using its index.
-     * 
-     * @param index the index where the buffer is located in this pointer.
-     * @return the buffer corresponding to this index.
-     */
-    void* getItem(int index);
+    private:
+        int count = 0;
+        int isProcessed = 0;
+
 };
-
 
 #endif

--- a/serial4j-native/src/include/JniUtils.h
+++ b/serial4j-native/src/include/JniUtils.h
@@ -322,6 +322,12 @@ namespace JniUtils {
         (*JniUtils::getJniEnv())->SetBooleanArrayRegion(booleanArray, 0, length, buffer);
         return booleanArray;
     }
+
+    static inline const cc_t* getReadConfiguration(jobject* object) {
+          jint fd = JniUtils::getPortDescriptorFromSerialPort(object);
+          const cc_t* readConfigBuffer = TerminalDevice::getReadConfigurationMode(&fd);
+          return readConfigBuffer;
+    }
 }
 
 #endif

--- a/serial4j-native/src/include/linux/TerminalDevice.h
+++ b/serial4j-native/src/include/linux/TerminalDevice.h
@@ -84,7 +84,7 @@ namespace TerminalDevice {
      * @return int (-3) if the directory ["/dev"] is invalid, (-4) if there are no tty
      * devices available at the ["/dev"] directory, (1) if operation succeeded.
      */
-    int fetchSerialPorts(struct DynamicBuffer* serialPorts);
+    int fetchSerialPorts(DynamicBuffer* serialPorts);
 
     /**
      * @brief Opens a serial port device with a name.

--- a/serial4j-native/src/lib/DynamicBuffer.cpp
+++ b/serial4j-native/src/lib/DynamicBuffer.cpp
@@ -1,7 +1,7 @@
 #include<DynamicBuffer.h>
 
 void DynamicBuffer::add(void* item) {
-  
+
     /* move the pointer to point to the last item */
     /* then, obtain a superficial copy */
     void** copy = (buffer += count);
@@ -23,23 +23,17 @@ void DynamicBuffer::add(int index, void* item) {
 
 void DynamicBuffer::removeAt(int index) {
     BufferUtils::nullifyBuffer(buffer, index);
-    BufferUtils::reValidateBuffer(buffer, getItemsCount(), &(this->isProcessed));
-    
-    while (!this->isProcessed);
-    this->isProcessed = 0;
+    BufferUtils::reValidateBuffer(buffer, *getItemsCount());
     
     count--;
 }
 
 void DynamicBuffer::removeAll() {
-    for (int i = 0; i < *(this->getItemsCount()); i++) {
+    for (int i = 0; i < count; i++) {
         BufferUtils::nullifyBuffer(buffer, i);
     }
 
-    BufferUtils::reValidateBuffer(buffer, getItemsCount(), &(this->isProcessed));
-    
-    while (!this->isProcessed);
-    this->isProcessed = 0;
+    BufferUtils::reValidateBuffer(buffer, *getItemsCount());
 
     this->resetDataPointer();
 }

--- a/serial4j-native/src/lib/jni/com_serial4j_core_serial_NativeTerminalDevice.cpp
+++ b/serial4j-native/src/lib/jni/com_serial4j_core_serial_NativeTerminalDevice.cpp
@@ -41,16 +41,7 @@
 #include<stdlib.h>
 #include<JniUtils.h>
 
-struct DynamicBuffer serialPorts;
-cc_t* config = (cc_t*) calloc(2, sizeof(cc_t));
-
-const cc_t* getReadConfiguration(jobject* object);
-
-const cc_t* getReadConfiguration(jobject* object) {
-    jint fd = JniUtils::getPortDescriptorFromSerialPort(object);
-    const cc_t* readConfigBuffer = TerminalDevice::getReadConfigurationMode(&fd);
-    return readConfigBuffer;
-}
+DynamicBuffer serialPorts;
 
 JNIEXPORT jint JNICALL Java_com_serial4j_core_serial_NativeTerminalDevice_setupJniEnvironment0
   (JNIEnv* env, jclass clazz) {
@@ -115,7 +106,7 @@ JNIEXPORT jint JNICALL Java_com_serial4j_core_serial_NativeTerminalDevice_setRea
 
 JNIEXPORT jintArray JNICALL Java_com_serial4j_core_serial_NativeTerminalDevice_getReadConfigurationMode0
   (JNIEnv* env, jobject object) {
-    const cc_t* readConfig = getReadConfiguration(&object);
+    const cc_t* readConfig = JniUtils::getReadConfiguration(&object);
     int* buffer = (int*) calloc(2, sizeof(int));
     buffer[0] = readConfig[0];
     buffer[1] = readConfig[1];
@@ -146,7 +137,8 @@ JNIEXPORT jlong JNICALL Java_com_serial4j_core_serial_NativeTerminalDevice_write
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_serial_NativeTerminalDevice_readData0
   (JNIEnv* env, jobject object) {
     jint fd = JniUtils::getPortDescriptorFromSerialPort(&object);
-    int length = getReadConfiguration(&object)[1] <= 0 ? getReadConfiguration(&object)[1] : 1;
+    int length = JniUtils::getReadConfiguration(&object)[1] <= 0 ?
+                                    JniUtils::getReadConfiguration(&object)[1] : 1;
     
     jchar* buffer = (jchar*) calloc(length, sizeof(jchar));
     int state = TerminalDevice::readData((void*) buffer, length, &fd);

--- a/serial4j-native/src/lib/linux/TerminalDevice.cpp
+++ b/serial4j-native/src/lib/linux/TerminalDevice.cpp
@@ -14,7 +14,7 @@ int TerminalDevice::openPort(const char* port, int flag) {
     return open(port, flag);
 }
 
-int TerminalDevice::fetchSerialPorts(struct DynamicBuffer* serialPorts) {
+int TerminalDevice::fetchSerialPorts(DynamicBuffer* serialPorts) {
 
     DIR* dirp = opendir(DEVICES_DIR);
     


### PR DESCRIPTION
This PR optimizes the C/C++ API by fixing some verbose leakable objects: 
- [x] BufferUtils#freeBufferCells(void**, count): corrected the order of commands, free memory then nullify pointers.
- [x] BufferUtils: removed unnecessary indirection operations.
- [x] DynamicBuffer.h: refactored to complete C++ class with a constructor and destructor.
- [x] DynamicBuffer.cpp: removed unnecessary indirection operations and `isProcessed` primitive locking mechanism (weak and erroneous).