### PR TITLE
Fix monitor threading

### DIFF
--- a/serial4j-examples/src/main/java/com/serial4j/example/jme/RollingTheMonkey.java
+++ b/serial4j-examples/src/main/java/com/serial4j/example/jme/RollingTheMonkey.java
@@ -64,16 +64,21 @@ import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.serial4j.core.serial.entity.EntityStatus;
+import com.serial4j.core.serial.entity.impl.SerialReadEntity;
+import com.serial4j.core.serial.entity.impl.SerialWriteEntity;
 import com.serial4j.core.terminal.control.BaudRate;
 import com.serial4j.core.serial.monitor.SerialDataListener;
 import com.serial4j.core.serial.monitor.SerialMonitor;
+
+import javax.swing.*;
 
 /**
  * Physics based marble game.
  * 
  * @author SkidRunner (Mark E. Picknell)
  */
-public class RollingTheMonkey extends SimpleApplication implements SerialDataListener, ActionListener, PhysicsCollisionListener {
+public class RollingTheMonkey extends SimpleApplication implements SerialDataListener, ActionListener, PhysicsCollisionListener, EntityStatus<SerialReadEntity> {
 
     private static final String MESSAGE         = "Thanks for Playing!";
     private static final String INFO_MESSAGE    = "Collect all the spinning cubes!\nPress the 'R' key any time to reset!";
@@ -117,6 +122,7 @@ public class RollingTheMonkey extends SimpleApplication implements SerialDataLis
     public void simpleInitApp() {
         try {
             serialMonitor = new SerialMonitor("Embedded-Controller");
+            serialMonitor.setReadEntityListener(this);
             serialMonitor.startDataMonitoring("/dev/ttyUSB0", BaudRate.B57600, null);
             serialMonitor.addSerialDataListener(this);
         } catch(FileNotFoundException e) {
@@ -472,5 +478,27 @@ public class RollingTheMonkey extends SimpleApplication implements SerialDataLis
         // Reset the message
         messageText.setLocalScale(0.0f);
     }
-    
+
+    @Override
+    public void onSerialEntityInitialized(SerialReadEntity serialMonitorEntity) {
+
+    }
+
+    @Override
+    public void onSerialEntityTerminated(SerialReadEntity serialMonitorEntity) {
+
+    }
+
+    @Override
+    public void onUpdate(SerialReadEntity serialMonitorEntity) {
+
+    }
+
+    @Override
+    public void onExceptionThrown(Exception e) {
+        JOptionPane.showMessageDialog(null, "Reading Serial data has failed, Terminating now!",
+                e.getMessage(), JOptionPane.ERROR_MESSAGE);
+        serialMonitor.setTerminate();
+        stop();
+    }
 }

--- a/serial4j-examples/src/main/java/com/serial4j/example/monitor/HelloSerialMonitor.java
+++ b/serial4j-examples/src/main/java/com/serial4j/example/monitor/HelloSerialMonitor.java
@@ -109,6 +109,11 @@ public class HelloSerialMonitor implements SerialDataListener, EntityStatus<Seri
     }
 
     @Override
+    public void onExceptionThrown(Exception e) {
+
+    }
+
+    @Override
     public void onDataReceived(int data) {
         
     }

--- a/serial4j/src/main/java/com/serial4j/core/serial/entity/EntityStatus.java
+++ b/serial4j/src/main/java/com/serial4j/core/serial/entity/EntityStatus.java
@@ -61,4 +61,11 @@ public interface EntityStatus<T extends SerialMonitorEntity> {
      * @param serialMonitorEntity the serial entity object.
      */
     void onUpdate(final T serialMonitorEntity);
+
+    /**
+     * Fired when an exception is thrown in the monitor entity task.
+     *
+     * @param e the exception thrown on this stack.
+     */
+    void onExceptionThrown(Exception e);
 }

--- a/serial4j/src/main/java/com/serial4j/core/serial/entity/SerialMonitorEntity.java
+++ b/serial4j/src/main/java/com/serial4j/core/serial/entity/SerialMonitorEntity.java
@@ -78,13 +78,20 @@ public abstract class SerialMonitorEntity implements Runnable {
         /* using re-entrant block to be optimized by the new v-threads system */
         try {
             reentrantLock.lock();
-            if (!hasLoggedMonitor) {
-                entityLogger.log(Level.INFO, "Started data monitoring for " + entityName + " thread " + Thread.currentThread());
-            }
+            logStart();
             onDataMonitored(getSerialMonitor());
         } finally {
             reentrantLock.unlock();
         }
+    }
+
+    /**
+     * Provides a JUL logger object for descendant objects to re-use.
+     *
+     * @return this entity logger instance.
+     */
+    protected Logger getEntityLogger() {
+        return entityLogger;
     }
 
     /**
@@ -109,6 +116,15 @@ public abstract class SerialMonitorEntity implements Runnable {
                 }
             }
         }
+    }
+
+    private void logStart() {
+        if(!hasLoggedMonitor) {
+            return;
+        }
+        entityLogger.log(Level.INFO,
+                "Started data monitoring for " + entityName + " thread " + Thread.currentThread());
+        hasLoggedMonitor = false; // shut down logging
     }
 
     /**


### PR DESCRIPTION
This PR fixes the thread monitoring issues, and introduces a better way to exception handling inside a SerialEntity by forwarding this exception into a strategy pattern:
- [x] Fix thread monitoring issues.
- [x] Introduced `SerialEntityStatus#onExceptionThrown(Exception)`