### PR TITLE
Introducing Virtual serial monitor and Native buffer streams

### DIFF
--- a/serial4j-examples/src/main/java/com/serial4j/example/monitor/TestVirtualMonitor.java
+++ b/serial4j-examples/src/main/java/com/serial4j/example/monitor/TestVirtualMonitor.java
@@ -1,0 +1,139 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2022, Scrappers Team, The AVR-Sandbox Project, Serial4j API.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.serial4j.example.monitor;
+
+import com.serial4j.core.serial.entity.EntityStatus;
+import com.serial4j.core.serial.entity.impl.SerialReadEntity;
+import com.serial4j.core.serial.entity.impl.SerialWriteEntity;
+import com.serial4j.core.serial.entity.impl.WritableCapsule;
+import com.serial4j.core.serial.monitor.SerialDataListener;
+import com.serial4j.core.serial.monitor.VirtualMonitor;
+import com.serial4j.core.terminal.NativeTerminalDevice;
+import com.serial4j.core.terminal.Permissions;
+import com.serial4j.core.terminal.control.BaudRate;
+import java.io.IOException;
+
+/**
+ * Tests the virtual monitor on the Java Streams {@link VirtualMonitor}.
+ *
+ * @author pavl_g
+ */
+public final class TestVirtualMonitor {
+    public static void main(String[] args) throws IOException {
+        final byte[] x = new byte[]{0};
+        final byte[] y = new byte[]{0};
+        final String[] data = new String[] {""};
+
+        final VirtualMonitor virtualMonitor = new VirtualMonitor("ttyVirtual-monitor");
+        virtualMonitor.setUseReturnCarriage(true);
+        virtualMonitor.setReadEntityListener(new EntityStatus<>() {
+            @Override
+            public void onSerialEntityInitialized(SerialReadEntity serialMonitorEntity) {
+
+            }
+
+            @Override
+            public void onSerialEntityTerminated(SerialReadEntity serialMonitorEntity) {
+
+            }
+
+            @Override
+            public void onUpdate(SerialReadEntity serialMonitorEntity) {
+                /* seeks the Java Streams back to zero before attempting further reading operations */
+                virtualMonitor.getTerminalDevice().seek(0, NativeTerminalDevice.FileSeekCriterion.SEEK_SET);
+            }
+
+            @Override
+            public void onExceptionThrown(Exception e) {
+
+            }
+        });
+        virtualMonitor.addSerialDataListener(new SerialDataListener() {
+            @Override
+            public void onDataReceived(int data) {
+            }
+
+            @Override
+            public void onDataTransmitted(int data) {
+            }
+
+            @Override
+            public void onDataReceived(String data) {
+                System.out.print("Data frame received = " + data.replace("\r", ""));
+            }
+        });
+
+        virtualMonitor.setWriteEntityStatus(new EntityStatus<>() {
+            @Override
+            public void onSerialEntityInitialized(SerialWriteEntity serialMonitorEntity) {
+
+            }
+
+            @Override
+            public void onSerialEntityTerminated(SerialWriteEntity serialMonitorEntity) {
+
+            }
+
+            @Override
+            public void onUpdate(SerialWriteEntity serialMonitorEntity) {
+
+                final WritableCapsule writableCapsule = new WritableCapsule();
+                writableCapsule.write(data[0]);
+                serialMonitorEntity.addWritableCapsule(writableCapsule);
+                /* seeks the Java Streams back to zero */
+                serialMonitorEntity.getSerialMonitor()
+                        .getTerminalDevice().seek(0, NativeTerminalDevice.FileSeekCriterion.SEEK_SET);
+
+                x[0] += 10;
+                y[0] += 20;
+                data[0] = String.format("[x = %d, y = %d]\n\r", x[0], y[0]);
+
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onExceptionThrown(Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        final Permissions permissions = Permissions.createEmptyPermissions()
+                .append(Permissions.Const.O_RDWR)
+                .append(Permissions.Const.O_CREATE);
+        virtualMonitor.startDataMonitoring(args[0], BaudRate.B0, permissions);
+    }
+}

--- a/serial4j-examples/src/main/java/com/serial4j/example/serial4j/TestNativeInputStream.java
+++ b/serial4j-examples/src/main/java/com/serial4j/example/serial4j/TestNativeInputStream.java
@@ -1,0 +1,63 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2022, Scrappers Team, The Arithmos Project.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS
+ */
+
+package com.serial4j.example.serial4j;
+
+import com.serial4j.core.serial.SerialPort;
+import com.serial4j.core.terminal.NativeBufferInputStream;
+import com.serial4j.core.terminal.Permissions;
+import com.serial4j.core.terminal.TerminalDevice;
+
+/**
+ * Isolates and tests the {@link NativeBufferInputStream} API.
+ *
+ * @author pavl_g
+ */
+public final class TestNativeInputStream {
+    public static void main(String[] args) {
+        final TerminalDevice ttyDevice = new TerminalDevice();
+        final Permissions permissions = Permissions.createEmptyPermissions()
+                        .append(Permissions.Const.O_CREATE, Permissions.Const.O_RDWR);
+        ttyDevice.setPermissions(permissions);
+        ttyDevice.openPort(new SerialPort(args[0]));
+        try (final NativeBufferInputStream inputStream = new NativeBufferInputStream(ttyDevice)) {
+            final StringBuffer buffer = new StringBuffer();
+            while (inputStream.read() > 0) {
+                buffer.append(inputStream.getBuffer());
+                if (buffer.toString().contains("\n\r")) {
+                    break;
+                }
+            }
+            System.out.println(buffer);
+        }
+    }
+}

--- a/serial4j-native/CMakeLists.txt
+++ b/serial4j-native/CMakeLists.txt
@@ -36,7 +36,6 @@ set(jni_sources "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/jni/com_serial4j_core_termi
                 "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/jni/com_serial4j_core_terminal_control_NativeTerminalFlags_OutputFlags.cpp"
                 "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/jni/com_serial4j_core_terminal_control_NativeTerminalFlags_OutputFlags_MaskBits.cpp"
                 "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/jni/com_serial4j_core_terminal_NativeTerminalDevice_FileSeekCriterion.cpp")
-
 set(sources "${jni_sources}"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/linux/TerminalDevice.cpp"
             "${CMAKE_CURRENT_SOURCE_DIR}/src/lib/AddressesBuffer.cpp")

--- a/serial4j-native/src/include/jni/com_serial4j_core_terminal_NativeTerminalDevice.h
+++ b/serial4j-native/src/include/jni/com_serial4j_core_terminal_NativeTerminalDevice.h
@@ -137,18 +137,26 @@ JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_wri
 
 /*
  * Class:     com_serial4j_core_terminal_NativeTerminalDevice
- * Method:    read
+ * Method:    sread
  * Signature: ()J
  */
-JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_read__
+JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_sread__
   (JNIEnv *, jobject);
 
 /*
  * Class:     com_serial4j_core_terminal_NativeTerminalDevice
- * Method:    read
+ * Method:    sread
  * Signature: (I)J
  */
-JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_read__I
+JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_sread__I
+  (JNIEnv *, jobject, jint);
+
+/*
+ * Class:     com_serial4j_core_terminal_NativeTerminalDevice
+ * Method:    iread
+ * Signature: (I)J
+ */
+JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_iread
   (JNIEnv *, jobject, jint);
 
 /*

--- a/serial4j-native/src/lib/jni/com_serial4j_core_terminal_NativeTerminalDevice.cpp
+++ b/serial4j-native/src/lib/jni/com_serial4j_core_terminal_NativeTerminalDevice.cpp
@@ -158,7 +158,7 @@ JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_wri
     return state;
 }
 
-JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_read
+JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_sread__
   (JNIEnv* env, jobject object) {
 
     int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
@@ -177,7 +177,7 @@ JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_rea
     return numberOfReadChars;
 }
 
-JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_read__I
+JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_sread__I
   (JNIEnv* env, jobject object, jint length) {
     int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
 
@@ -189,6 +189,24 @@ JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_rea
     /* get the java string buffer and setup its data with the buffer */
     JniUtils::setObjectField(env, &object, "readBuffer", "Ljava/lang/String;", env->NewStringUTF(strBuffer));
     return numberOfReadChars;
+}
+
+JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_iread
+  (JNIEnv* env, jobject object, jint length) {
+    int fd = JniUtils::getPortDescriptorFromSerialPort(env, &object);
+
+    /* create the buffer and initialize it with zero */
+    jchar buffer[length + 1];
+    memset(buffer, '\0', sizeof(buffer));
+
+    /* read data into the buffer */
+    int bytes = TerminalDevice::readData((void*) buffer, length, &fd);
+
+    /* send the data to the Java buffer */
+    jcharArray array = JniUtils::getCharArrayFromBuffer(env, buffer, length);
+    JniUtils::setObjectField(env, &object, "buffer", "[C", array);
+
+    return bytes;
 }
 
 JNIEXPORT jlong JNICALL Java_com_serial4j_core_terminal_NativeTerminalDevice_seek

--- a/serial4j/src/main/java/com/serial4j/core/serial/monitor/VirtualMonitor.java
+++ b/serial4j/src/main/java/com/serial4j/core/serial/monitor/VirtualMonitor.java
@@ -8,9 +8,15 @@ import com.serial4j.core.terminal.NativeBufferInputStream;
 import com.serial4j.core.terminal.NativeBufferOutputStream;
 import com.serial4j.core.terminal.Permissions;
 import com.serial4j.core.terminal.control.BaudRate;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
+/**
+ * A virtual monitor isolates the {@link SerialReadEntity} and the {@link SerialWriteEntity}
+ * actions from the terminal based operations, the virtual monitor can act on both regular and
+ * terminal files, as well, it just isolates the native IO operations.
+ *
+ * @author pavl_g
+ */
 public class VirtualMonitor extends SerialMonitor {
 
     /**
@@ -27,12 +33,14 @@ public class VirtualMonitor extends SerialMonitor {
     }
 
     @Override
-    public void startDataMonitoring(String port, BaudRate baudRate, Permissions permissions) throws NoSuchDeviceException, PermissionDeniedException, BrokenPipeException, InvalidPortException, NoAvailableTtyDevicesException, FileNotFoundException {
+    public void startDataMonitoring(String port, BaudRate baudRate, Permissions permissions) throws NoSuchDeviceException,
+            PermissionDeniedException, BrokenPipeException, InvalidPortException, NoAvailableTtyDevicesException {
+
         terminalDevice.setSerial4jLoggingEnabled(true);
         if (permissions != null) {
             terminalDevice.setPermissions(permissions);
         }
-        terminalDevice.setSerial4jLoggingEnabled(false);
+
         readEntityStream = new NativeBufferInputStream(terminalDevice);
         writeEntityStream = new NativeBufferOutputStream(terminalDevice);
 
@@ -52,6 +60,13 @@ public class VirtualMonitor extends SerialMonitor {
         monitorThread.start();
     }
 
+    /**
+     * Changes the mode access of a script and runs an action aftermath.
+     *
+     * @param flags                 the mode access flags (eg: +rwx)
+     * @param script                the script or the file to grant it the permissions
+     * @param afterChangeModeAccess a runnable action to execute afterward
+     */
     protected void chmod(String flags, String script, Runnable afterChangeModeAccess) {
         try {
             // change mode access to read/write/execute

--- a/serial4j/src/main/java/com/serial4j/core/serial/monitor/VirtualMonitor.java
+++ b/serial4j/src/main/java/com/serial4j/core/serial/monitor/VirtualMonitor.java
@@ -1,0 +1,73 @@
+package com.serial4j.core.serial.monitor;
+
+import com.serial4j.core.serial.SerialPort;
+import com.serial4j.core.serial.entity.impl.SerialReadEntity;
+import com.serial4j.core.serial.entity.impl.SerialWriteEntity;
+import com.serial4j.core.serial.throwable.*;
+import com.serial4j.core.terminal.NativeBufferInputStream;
+import com.serial4j.core.terminal.NativeBufferOutputStream;
+import com.serial4j.core.terminal.Permissions;
+import com.serial4j.core.terminal.control.BaudRate;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class VirtualMonitor extends SerialMonitor {
+
+    /**
+     * Instantiates a new virtual monitor with a name (acting on filesystem only).
+     * <p>
+     * Use {@link SerialMonitor#startDataMonitoring(String, BaudRate, Permissions)} to initialize and start
+     * data monitoring.
+     * </p>
+     *
+     * @param monitorName the name for this monitor.
+     */
+    public VirtualMonitor(String monitorName) {
+        super(monitorName);
+    }
+
+    @Override
+    public void startDataMonitoring(String port, BaudRate baudRate, Permissions permissions) throws NoSuchDeviceException, PermissionDeniedException, BrokenPipeException, InvalidPortException, NoAvailableTtyDevicesException, FileNotFoundException {
+        terminalDevice.setSerial4jLoggingEnabled(true);
+        if (permissions != null) {
+            terminalDevice.setPermissions(permissions);
+        }
+        terminalDevice.setSerial4jLoggingEnabled(false);
+        readEntityStream = new NativeBufferInputStream(terminalDevice);
+        writeEntityStream = new NativeBufferOutputStream(terminalDevice);
+
+        serialWriteEntity = new SerialWriteEntity(this);
+        serialReadEntity = new SerialReadEntity(this);
+
+        terminalDevice.openPort(new SerialPort(port));
+
+        chmod("+rw", port, () -> monitorThread = new Thread(() -> {
+            while (!isTerminate()) {
+                /* change mode access and start data monitoring */
+                serialWriteEntity.run();
+                serialReadEntity.run();
+            }
+        }, monitorName));
+
+        monitorThread.start();
+    }
+
+    protected void chmod(String flags, String script, Runnable afterChangeModeAccess) {
+        try {
+            // change mode access to read/write/execute
+            ProcessBuilder builder = new ProcessBuilder().command("chmod", flags, script);
+            builder.start().onExit().thenApply(process -> {
+                afterChangeModeAccess.run();
+                process.destroy();
+                return null;
+            });
+        } catch (IOException e) {
+            if (serialReadEntityEntityStatus != null) {
+                serialReadEntityEntityStatus.onExceptionThrown(e);
+            }
+            if (serialWriteEntityEntityStatus != null) {
+                serialWriteEntityEntityStatus.onExceptionThrown(e);
+            }
+        }
+    }
+}

--- a/serial4j/src/main/java/com/serial4j/core/terminal/NativeBufferInputStream.java
+++ b/serial4j/src/main/java/com/serial4j/core/terminal/NativeBufferInputStream.java
@@ -1,0 +1,181 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2022, Scrappers Team, The AVR-Sandbox Project, Serial4j API.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.serial4j.core.terminal;
+
+import java.io.InputStream;
+
+/**
+ * Adapts the low-level native file IO API to Java Input Stream.
+ *
+ * @author pavl_g
+ */
+public class NativeBufferInputStream extends InputStream {
+
+    /**
+     * The terminal device associated with this stream.
+     */
+    protected final TerminalDevice terminalDevice;
+
+    /**
+     * Instantiates a Java input stream on top of a terminal
+     * device.
+     *
+     * @param terminalDevice the terminal device holding the FD to associate
+     *                       this Java stream with
+     */
+    public NativeBufferInputStream(final TerminalDevice terminalDevice) {
+        this.terminalDevice = terminalDevice;
+    }
+
+    /**
+     * @deprecated use {@link NativeBufferInputStream#read()} instead.
+     */
+    @Deprecated
+    @Override
+    public int available() {
+        throw new UnsupportedOperationException("No longer supported in this native stream!");
+    }
+
+    /**
+     * Seeks the stream back to its start position.
+     *
+     * <p>
+     * Side-effect: a dispatch to this function in a real {@link TerminalDevice} context (not virtual) will
+     * crash the application with the exception {@link com.serial4j.core.serial.throwable.IllegalSeekException}.
+     * </p>
+     */
+    @Override
+    public void reset() {
+        terminalDevice.seek(0, NativeTerminalDevice.FileSeekCriterion.SEEK_SET);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) {
+        final char[] buffer = new char[b.length];
+        for (int i = 0; i < b.length; i++) {
+            buffer[i] = (char) b[i];
+        }
+        return (int) read(buffer, off, len);
+    }
+
+    /**
+     * Reads the next byte and saves it to the buffer.
+     *
+     * <p>
+     * Note: a dispatch to this method produces a side effect, it
+     * basically replaces all the elements in the buffer with
+     * the read byte.
+     * </p>
+     *
+     * <p>
+     * Note: a dispatch to this method produces another side effect, the stream IO operation
+     * is being sought forward towards its end, to negate this side effect, a dispatch to
+     * {@link NativeTerminalDevice#seek(long, int)} or {@link NativeBufferInputStream#reset()} is a must.
+     * </p>
+     *
+     * @return the next byte in this input stream
+     */
+    @Override
+    public int read() {
+        return (int) terminalDevice.iread(1);
+    }
+
+    /**
+     * Reads bytes into the main buffer and copies them to the user buffer.
+     *
+     * <p>
+     * Note: a dispatch to this method produces a side effect, it
+     * basically replaces all the elements in the buffer with
+     * the read bytes.
+     * </p>
+     *
+     * <p>
+     * Note: a dispatch to this method produces another side effect, the stream IO operation
+     * is being sought forward towards its end, to negate this side effect, a dispatch to
+     * {@link NativeTerminalDevice#seek(long, int)} or {@link NativeBufferInputStream#reset()} is a must.
+     * </p>
+     *
+     * @param buffer the user buffer that the data will be copied to
+     * @param offset the start position of the reading operation
+     * @param length the end position of the reading operation
+     * @return the number of bytes read
+     */
+    public long read(char[] buffer, int offset, int length) {
+        try {
+            return readOffset(offset, length);
+        } finally {
+            System.arraycopy(getBuffer(), 0, buffer, 0, buffer.length);
+        }
+    }
+
+    /**
+     * Reads bytes into the main buffer with a start position
+     * and an end position determined by the offset and the length.
+     *
+     * <p>
+     * Note: a dispatch to this method produces a side effect, it
+     * basically replaces all the elements in the buffer with
+     * the read bytes.
+     * </p>
+     *
+     * <p>
+     * Note: a dispatch to this method produces another side effect, the stream IO operation
+     * is being sought forward towards its end, to negate this side effect, a dispatch to
+     * {@link NativeTerminalDevice#seek(long, int)} or {@link NativeBufferInputStream#reset()} is a must.
+     * </p>
+     *
+     * @param offset the start position of the read operation
+     * @param length the end position of the read operation
+     * @return the number of the read bytes
+     */
+    public long readOffset(int offset, int length) {
+         // seek to an offset
+        terminalDevice.seek(offset, NativeTerminalDevice.FileSeekCriterion.SEEK_SET);
+        // read from that offset into a buffer
+        return terminalDevice.iread(length);
+    }
+
+    @Override
+    public void close() {
+        terminalDevice.closePort();
+    }
+
+    /**
+     * Retrieves the read buffer.
+     *
+     * @return the buffer of the read data
+     */
+    public char[] getBuffer() {
+        return terminalDevice.getBuffer();
+    }
+}

--- a/serial4j/src/main/java/com/serial4j/core/terminal/NativeBufferOutputStream.java
+++ b/serial4j/src/main/java/com/serial4j/core/terminal/NativeBufferOutputStream.java
@@ -1,0 +1,69 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2022, Scrappers Team, The AVR-Sandbox Project, Serial4j API.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.serial4j.core.terminal;
+
+import java.io.OutputStream;
+
+/**
+ * Adapts the low-level native file IO API to Java Output Stream.
+ *
+ * @author pavl_g
+ */
+public class NativeBufferOutputStream extends OutputStream {
+
+    /**
+     * The terminal device associated with this stream.
+     */
+    protected final TerminalDevice terminalDevice;
+
+    /**
+     * Instantiates a Java output stream on top of a terminal
+     * device.
+     *
+     * @param terminalDevice the terminal device holding the FD to associate
+     *                       this Java stream with
+     */
+    public NativeBufferOutputStream(final TerminalDevice terminalDevice) {
+        this.terminalDevice = terminalDevice;
+    }
+
+    @Override
+    public void write(int b) {
+        terminalDevice.write(b);
+    }
+
+    @Override
+    public void close() {
+        terminalDevice.closePort();
+    }
+}

--- a/serial4j/src/main/java/com/serial4j/core/terminal/NativeTerminalDevice.java
+++ b/serial4j/src/main/java/com/serial4j/core/terminal/NativeTerminalDevice.java
@@ -29,6 +29,7 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
 package com.serial4j.core.terminal;
 
 import com.serial4j.core.serial.SerialPort;
@@ -57,6 +58,8 @@ public final class NativeTerminalDevice {
     private SerialPort serialPort;
     private String[] serialPorts;
     private String readBuffer;
+
+    private char[] buffer;
 
     /**
      * Creates a native terminal device after
@@ -104,17 +107,26 @@ public final class NativeTerminalDevice {
 
     /**
      * Retrieves the read buffer in a string format after
-     * dispatching {@link NativeTerminalDevice#read()}.
+     * dispatching {@link NativeTerminalDevice#sread()}.
      *
      * <p>
      * The read buffer is a native const char*, settled natively by reading data
-     * frames using {@link NativeTerminalDevice#read()}.
+     * frames using {@link NativeTerminalDevice#sread()}.
      * </p>
      *
      * @return the buffer in string format
      */
     public String getReadBuffer() {
         return this.readBuffer;
+    }
+
+    /**
+     * Retrieves the buffer output of the "iread(int)" operation.
+     *
+     * @return the output of the "iread(int)" operation
+     */
+    public char[] getBuffer() {
+        return buffer;
     }
 
     /**
@@ -291,7 +303,7 @@ public final class NativeTerminalDevice {
      *
      * @return the number of read bytes from this terminal device.
      */
-    native long read();
+    native long sread();
 
     /**
      * Reads the data from this file-system and inserts the result into the {@link NativeTerminalDevice#readBuffer}
@@ -300,7 +312,16 @@ public final class NativeTerminalDevice {
      * @param length the length of the reading buffer
      * @return the number of read bytes
      */
-    native long read(final int length);
+    native long sread(final int length);
+
+    /**
+     * Reads the data from this file-system and inserts the result into the {@link NativeTerminalDevice#getBuffer()}
+     * buffer.
+     *
+     * @param length the number of the bytes to read into the buffer
+     * @return the number of the read bytes
+     */
+    native long iread(final int length);
 
     /**
      * Seeks the current position of this file-system according to the


### PR DESCRIPTION
This major PR introduces the `VirtualMonitor` API, an elegant way of isolating the native file IO API from the terminal-based operations, by introducing the `VirtualMonitor` one could test the performance of the native Serial4j without the need to write unit tests from scratch, in fact, the `VirtualMonitor` is a great example of unit test APIs: 
- [x] VirtualMonitor.
- [x] NativeBufferInputStream.
- [x] NativeBufferOutputStream.
- [x] TestVirtualMonitor.
- [x] TestNativeInputStream.

> Note: 
> There are breaking changes taking place at the `Permissions` and `TerminalFlag` APIs.
> These changes are not addressed in this PR!
>    