### PR TITLE
SerialMonitor-API: simplified SerialDataListener to a single listener for maintenance reasons

### DIFF
--- a/serial4j-examples/src/main/java/com/serial4j/example/jme/RollingTheMonkey.java
+++ b/serial4j-examples/src/main/java/com/serial4j/example/jme/RollingTheMonkey.java
@@ -66,6 +66,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import com.serial4j.core.serial.entity.EntityStatus;
 import com.serial4j.core.serial.entity.impl.SerialReadEntity;
+import com.serial4j.core.serial.throwable.SerialThrowable;
 import com.serial4j.core.terminal.control.BaudRate;
 import com.serial4j.core.serial.monitor.SerialDataListener;
 import com.serial4j.core.serial.monitor.SerialMonitor;
@@ -128,7 +129,7 @@ public class RollingTheMonkey extends SimpleApplication implements SerialDataLis
             serialMonitor = new SerialMonitor("Embedded-Controller");
             serialMonitor.setReadEntityListener(this);
             serialMonitor.startDataMonitoring(args[0], BaudRate.B57600, null);
-            serialMonitor.addSerialDataListener(this);
+            serialMonitor.setSerialDataListener(this);
         } catch(FileNotFoundException e) {
             Logger.getLogger(getClass().getName())
                   .log(Level.SEVERE, "Monitor has failed!", e);
@@ -504,5 +505,10 @@ public class RollingTheMonkey extends SimpleApplication implements SerialDataLis
                 e.getMessage(), JOptionPane.ERROR_MESSAGE);
         serialMonitor.setTerminate();
         stop();
+        int error = -1;
+        if (e instanceof SerialThrowable) {
+            error = ((SerialThrowable) e).getCausingErrno().getValue();
+        }
+        System.exit(error);
     }
 }

--- a/serial4j-examples/src/main/java/com/serial4j/example/monitor/HelloSerialMonitor.java
+++ b/serial4j-examples/src/main/java/com/serial4j/example/monitor/HelloSerialMonitor.java
@@ -66,7 +66,7 @@ public class HelloSerialMonitor implements SerialDataListener, EntityStatus<Seri
                                                        .append(FilePermissions.OperativeConst.O_NOCTTY);
             serialMonitor.startDataMonitoring("/dev/ttyUSB0", BaudRate.B57600, filePermissions);
             serialMonitor.setWriteEntityStatus(this);
-            serialMonitor.addSerialDataListener(this);
+            serialMonitor.setSerialDataListener(this);
 
              /* write data to UART with return-carriage/newline */
              delay(2000);

--- a/serial4j-examples/src/main/java/com/serial4j/example/monitor/TestVirtualMonitor.java
+++ b/serial4j-examples/src/main/java/com/serial4j/example/monitor/TestVirtualMonitor.java
@@ -55,7 +55,7 @@ public final class TestVirtualMonitor {
         final String[] data = new String[] {""};
 
         final VirtualMonitor virtualMonitor = new VirtualMonitor("ttyVirtual-monitor");
-        virtualMonitor.setUseReturnCarriage(true);
+        virtualMonitor.setProcessLinefeedCarriageReturn(true);
         virtualMonitor.setReadEntityListener(new EntityStatus<>() {
             @Override
             public void onSerialEntityInitialized(SerialReadEntity serialMonitorEntity) {
@@ -78,7 +78,7 @@ public final class TestVirtualMonitor {
 
             }
         });
-        virtualMonitor.addSerialDataListener(new SerialDataListener() {
+        virtualMonitor.setSerialDataListener(new SerialDataListener() {
             @Override
             public void onDataReceived(int data) {
             }

--- a/serial4j/src/main/java/com/serial4j/core/serial/entity/SerialMonitorEntity.java
+++ b/serial4j/src/main/java/com/serial4j/core/serial/entity/SerialMonitorEntity.java
@@ -39,14 +39,13 @@ import java.util.logging.Logger;
 import java.util.logging.Level;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 
 /**
  * Represents the base implementation for serial monitor Read and Write entities.
  *
+ * @author pavl_g.
  * @see com.serial4j.core.serial.entity.impl.SerialWriteEntity
  * @see com.serial4j.core.serial.entity.impl.SerialReadEntity
- * @author pavl_g.
  */
 public abstract class SerialMonitorEntity implements Runnable {
 
@@ -56,15 +55,15 @@ public abstract class SerialMonitorEntity implements Runnable {
     protected final ReentrantLock reentrantLock = new ReentrantLock();
 
     private final Logger entityLogger;
-    private boolean hasLoggedMonitor;
     private final SerialMonitor serialMonitor;
     private final String entityName;
+    private boolean hasLoggedMonitor;
 
     /**
      * Defines a serial monitor basic entity.
      *
      * @param serialMonitor the monitor object.
-     * @param entityName the entity name.
+     * @param entityName    the entity name.
      */
     public SerialMonitorEntity(SerialMonitor serialMonitor, String entityName) {
         this.serialMonitor = serialMonitor;
@@ -119,7 +118,7 @@ public abstract class SerialMonitorEntity implements Runnable {
     }
 
     private void logStart() {
-        if(!hasLoggedMonitor) {
+        if (!hasLoggedMonitor) {
             return;
         }
         entityLogger.log(Level.INFO,
@@ -132,8 +131,8 @@ public abstract class SerialMonitorEntity implements Runnable {
      *
      * @return true if [\n\r] check is enabled, default value is [true].
      */
-    protected boolean isUsingReturnCarriage() {
-        return getSerialMonitor().isUsingReturnCarriage();
+    protected boolean isProcessLinefeedCarriageReturn() {
+        return getSerialMonitor().isProcessLinefeedCarriageReturn();
     }
 
     /**
@@ -174,19 +173,19 @@ public abstract class SerialMonitorEntity implements Runnable {
     }
 
     /**
-     * Retrieves the serial data listeners list.
+     * Retrieves the serial data listener.
      *
-     * @return a list instance representing the serial data listeners.
+     * @return a reference to the serial data listener instance
      */
-    protected ArrayList<SerialDataListener> getSerialDataListeners() {
-        return getSerialMonitor().getSerialDataListeners();
+    protected SerialDataListener getSerialDataListener() {
+        return getSerialMonitor().getSerialDataListener();
     }
 
     /**
      * Tests whether the serial monitor holding this entity terminated.
-     * @see SerialMonitor#setTerminate()
      *
      * @return true if the serial monitor has been terminated by the user, default value is false.
+     * @see SerialMonitor#setTerminate()
      */
     protected boolean isTerminate() {
         return getSerialMonitor().isTerminate();
@@ -216,10 +215,9 @@ public abstract class SerialMonitorEntity implements Runnable {
     /**
      * Sets the serial entity initialized status.
      *
+     * @param state a state to set.
      * @see SerialMonitor#isReadSerialEntityInitialized
      * @see SerialMonitor#isWriteSerialEntityInitialized
-     *
-     * @param state a state to set.
      */
     protected abstract void setSerialEntityInitialized(boolean state);
 

--- a/serial4j/src/main/java/com/serial4j/core/serial/entity/impl/SerialReadEntity.java
+++ b/serial4j/src/main/java/com/serial4j/core/serial/entity/impl/SerialReadEntity.java
@@ -39,7 +39,6 @@ import com.serial4j.core.serial.monitor.SerialMonitorException;
 import com.serial4j.core.terminal.FilePermissions;
 import com.serial4j.core.terminal.NativeBufferInputStream;
 import com.serial4j.core.terminal.control.BaudRate;
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -96,28 +95,29 @@ public class SerialReadEntity extends SerialMonitorEntity {
         final NativeBufferInputStream nbis = (NativeBufferInputStream) getEntityStream();
 
         /* execute serial data tasks */
-        for (int i = 0; i < getSerialDataListeners().size(); i++) {
+        if (getSerialDataListener() != null) {
             try {
                 while (getEntityStream().read() > 0) {
                     /* send characters serially */
-                    getSerialDataListeners().get(i).onDataReceived(nbis.getBuffer()[0]);
+                    getSerialDataListener().onDataReceived(nbis.getBuffer()[0]);
 
                     /* get a string buffer from a data frame */
                     stringBuffer.append(nbis.getBuffer());
 
                     /* send data frames separated by [\n\r] the return carriage/newline */
-                    if (!isUsingReturnCarriage()) {
+                    if (!isProcessLinefeedCarriageReturn()) {
                         continue;
                     }
 
+                    /* LF/CR */
                     if (stringBuffer.toString().endsWith("\n\r")) {
-                        getSerialDataListeners().get(i).onDataReceived(stringBuffer.toString());
+                        getSerialDataListener().onDataReceived(stringBuffer.toString());
                         stringBuffer = new StringBuffer();
                         break;
                     }
                 }
-            } catch (IOException e) {
-                if (getSerialDataListeners() != null) {
+            } catch (Exception e) {
+                if (getSerialEntityStatusListener() != null) {
                     getSerialEntityStatusListener().onExceptionThrown(e);
                 }
             }

--- a/serial4j/src/main/java/com/serial4j/core/serial/entity/impl/SerialWriteEntity.java
+++ b/serial4j/src/main/java/com/serial4j/core/serial/entity/impl/SerialWriteEntity.java
@@ -99,10 +99,11 @@ public class SerialWriteEntity extends SerialMonitorEntity {
             /* send capsule data to the UART */
             final String data = capsule.getData();
             for (int i = 0; i < data.length(); i++) {
-                sendToUART(data.charAt(i));
-                for (int j = 0; j < getSerialDataListeners().size(); j++) {
-                    getSerialDataListeners().get(j).onDataTransmitted(data.charAt(i));
+                send(data.charAt(i));
+                if (getSerialDataListener() == null) {
+                    continue;
                 }
+                getSerialDataListener().onDataTransmitted(data.charAt(i));
             }
             capsule.setDataWritten(true);
         }
@@ -168,7 +169,7 @@ public class SerialWriteEntity extends SerialMonitorEntity {
      *
      * @param data the data to send in integers.
      */
-    private void sendToUART(final int data) {
+    private void send(final int data) {
         try {
             getEntityStream().write(data);
         } catch (IOException e) {


### PR DESCRIPTION
This PR refactors the serial monitor to use a single serial data listener through its entities (read and write entities).